### PR TITLE
Leave slashes in local file paths

### DIFF
--- a/R/sftp_functions.R
+++ b/R/sftp_functions.R
@@ -387,7 +387,7 @@ sftp_download <- function(file,
                           verbose = TRUE,
                           curl_options = list() ) {
 
-    tofolder <- trim_slashes(tofolder)
+    # tofolder <- trim_slashes(tofolder)
 
     using_wildcard <- FALSE
     if (length(file) == 1) {
@@ -478,7 +478,7 @@ sftp_upload <- function(file,
                         verbose = TRUE,
                         curl_options = list() ) {
 
-    fromfolder <- trim_slashes(fromfolder)
+  #  fromfolder <- trim_slashes(fromfolder)
 
     using_wildcard <- FALSE
     if (length(file) == 1) {


### PR DESCRIPTION
For some reason the upload and download functions trim leading slashes from local file paths, thus rendering them all as relative paths on linux. If there is a reason for the original implementation maybe there is another solution?
Fixes #15